### PR TITLE
remove auto select children/parent

### DIFF
--- a/treeview_lib/src/main/java/me/texy/treeview/TreeNode.kt
+++ b/treeview_lib/src/main/java/me/texy/treeview/TreeNode.kt
@@ -27,6 +27,7 @@ class TreeNode(var value: Any?) {
     var isExpanded = false
     var isSelected = false
     var isItemClickEnable = true
+    var willHaveChildren = false
 
     constructor(value: Any?, level: Int) : this(value) {
         this.level = level

--- a/treeview_lib/src/main/java/me/texy/treeview/TreeViewAdapter.kt
+++ b/treeview_lib/src/main/java/me/texy/treeview/TreeViewAdapter.kt
@@ -110,8 +110,6 @@ class TreeViewAdapter internal constructor(private val context: Context, private
 
     fun selectNode(checked: Boolean, treeNode: TreeNode) {
         treeNode.isSelected = checked
-        selectChildren(treeNode, checked)
-        selectParentIfNeed(treeNode, checked)
     }
 
     private fun selectChildren(treeNode: TreeNode, checked: Boolean) {


### PR DESCRIPTION
Hi @BobNies 

This fix will stop auto selecting children and the parent (if all children are selected). And also supports a new flag to allow setting if the node will have children that aren't yet loaded.

Thanks,
Jennie